### PR TITLE
Use the same sidebar logic that Solidus uses

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -6,6 +6,7 @@ class Spree::StaticContentController < Spree::StoreController
 
   def show
     @page = Spree::Page.by_store(current_store).visible.find_by_slug!(request.path)
+    @taxonomies = Spree::Taxonomy.includes(root: :children)
   end
 
   private

--- a/app/overrides/pages_in_menu.rb
+++ b/app/overrides/pages_in_menu.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/shared/_menu",
-                     :name => "static_content_pages_admin_tab",
-                     :insert_bottom => "[data-hook='admin_tabs']",
-                     :text => "<%= tab(:pages, label: 'Pages', icon: 'file-text') %>",
-                     :disabled => false)

--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -12,11 +12,13 @@
   <% end -%>
 
   <% content_for :sidebar do %>
-    <% if defined? @products && defined? @taxon %>
-      <%= render :partial => "spree/shared/filters" %>
-    <% elsif defined? @taxonomies %>
-      <%= render :partial => "spree/shared/taxonomies" %>
-    <% end %>
+    <div data-hook="homepage_sidebar_navigation">
+      <% if "spree/products" == params[:controller] && @taxon %>
+        <%= render :partial => 'spree/shared/filters' %>
+      <% else %>
+        <%= render :partial => 'spree/shared/taxonomies' %>
+      <% end %>
+    </div>
   <% end %>
 
   <h1><%= @page.title %></h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
   spree:
     admin:
       tab:
-        Pages: Pages
+        pages: Pages
     back_to_static_pages_list: "Back to static pages list"
     page: Page
     pages: Pages

--- a/lib/spree_static_content/engine.rb
+++ b/lib/spree_static_content/engine.rb
@@ -7,9 +7,11 @@ module SpreeStaticContent
     config.autoload_paths += %W(#{config.root}/lib)
 
     def self.activate
-      Dir.glob(File.join(File.dirname(__FILE__), "../../app/overrides/*.rb")) do |c|
-        Rails.configuration.cache_classes ? require(c) : load(c)
-      end
+       Spree::Backend::Config.menu_items << Spree::Backend::Config.class::MenuItem.new(
+        [:pages],
+        'file-text',
+        condition: -> { can?(:admin, Spree::Page) },
+      )
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
This change makes the default static_content sidebar use the same logic
that Solidus does in frontend/app/views/spree/products/index.html.erb.

The positive consequence of this change is that now, by default, static
content pages render the same default sidebar that Solidus pages do,
unifying the look and feel and making the static content pages look
"normal".