### PR TITLE
Fix the admin tab

### DIFF
--- a/app/overrides/pages_in_menu.rb
+++ b/app/overrides/pages_in_menu.rb
@@ -1,5 +1,0 @@
-Deface::Override.new(:virtual_path => "spree/admin/shared/_menu",
-                     :name => "static_content_pages_admin_tab",
-                     :insert_bottom => "[data-hook='admin_tabs']",
-                     :text => "<%= tab(:pages, label: 'Pages', icon: 'file-text') %>",
-                     :disabled => false)

--- a/app/views/spree/admin/shared/_static_content_admin_tab.html.erb
+++ b/app/views/spree/admin/shared/_static_content_admin_tab.html.erb
@@ -1,3 +1,3 @@
 <% if can?(:manage, Spree::Page) %>
-  <%= tab(:pages, label: 'Pages', icon: 'file-text') %>
+  <%= tab(:pages, icon: 'file-text') %>
 <% end %>

--- a/app/views/spree/admin/shared/_static_content_admin_tab.html.erb
+++ b/app/views/spree/admin/shared/_static_content_admin_tab.html.erb
@@ -1,0 +1,3 @@
+<% if can?(:manage, Spree::Page) %>
+  <%= tab(:pages, label: 'Pages', icon: 'file-text') %>
+<% end %>

--- a/lib/spree_static_content/engine.rb
+++ b/lib/spree_static_content/engine.rb
@@ -10,6 +10,22 @@ module SpreeStaticContent
       Dir.glob(File.join(File.dirname(__FILE__), "../../app/overrides/*.rb")) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
+      if SolidusSupport.solidus_gem_version >= Gem::Version.new("1.4.0")
+        Spree::Backend::Config.configure do |config|
+          config.menu_items << config.class::MenuItem.new(
+            [:pages],
+            'file-text',
+            condition: -> { can?(:manage, Spree::Page) },
+          )
+        end
+      else
+        Deface::Override.new(
+          virtual_path: "spree/admin/shared/_menu",
+          name: "static_content_pages_admin_tab",
+          insert_bottom: "[data-hook='admin_tabs']",
+          partial: "spree/admin/shared/static_content_admin_tab"
+        )
+      end
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
In Solidus < 1.4 we still need a Deface override, but need to check the permissions of the user, so it does not appear in the login screen.

For Solidus >= 1.4 we use the `Spree::Config::Backend::MenuItem` configuration.