### PR TITLE
Fixes visibility hidden of Page menu before login

### DIFF
--- a/app/overrides/pages_in_menu.rb
+++ b/app/overrides/pages_in_menu.rb
@@ -1,5 +1,10 @@
 Deface::Override.new(:virtual_path => "spree/admin/shared/_menu",
                      :name => "static_content_pages_admin_tab",
                      :insert_bottom => "[data-hook='admin_tabs']",
-                     :text => "<%= tab(:pages, label: 'Pages', icon: 'file-text') %>",
-                     :disabled => false)
+                     :disabled => false) do
+                      <<-HTML
+                        <% if can? :admin, Spree::Page %>
+                          <%= tab(:pages, label: 'Pages', icon: 'file-text') %>
+                        <% end %>
+                      HTML
+                     end


### PR DESCRIPTION
This simple fix solves the issue when the Page menu is displayed in the left-side bar before login.