### PR TITLE
Relax Deface dependency

### DIFF
--- a/solidus_static_content.gemspec
+++ b/solidus_static_content.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'solidus', ['>= 1.1', '< 3']
   s.add_dependency "solidus_support"
-  s.add_dependency 'deface', '~> 1.0.2'
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'capybara', '~> 2.7'
   s.add_development_dependency 'factory_bot', '~> 4.7'


### PR DESCRIPTION
This relaxes the Deface dependency to lock on the minor rather than patch version. It allows people to use the latest version of Nokogiri (the previous one throws a bunch of nasty deprecation warnings about `::Fixnum` on Ruby >= 2.4).

The tests pass, but let me know if I missed anything.
