### PR TITLE
fix migration scope

### DIFF
--- a/lib/generators/solidus_static_content/install/install_generator.rb
+++ b/lib/generators/solidus_static_content/install/install_generator.rb
@@ -8,7 +8,7 @@ module SolidusStaticContent
       end
 
       def add_migrations
-        run 'bundle exec rake railties:install:migrations FROM=solidus_static_content'
+        run 'bundle exec rake railties:install:migrations FROM=spree_static_content'
       end
 
       def run_migrations


### PR DESCRIPTION
quick fix for #4 

I think would be better keep ``solidus_static_content`` scope, but requires some extra work.