### PR TITLE
Add missing pessimistic versioning to rails-controller-testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 if branch == 'master' || branch >= "v2.0"
-  gem "rails-controller-testing", group: :test
+  gem 'rails-controller-testing', '~> 1.0', group: :test
 else
   gem "rails_test_params_backport"
   gem "rails", "~> 4.2.7"


### PR DESCRIPTION
The lack of pessimistic versioning for `rails-controller-testing` was causing Bundler to hang indefinitely when resolving dependencies for all **Solidus** versions.