### PR TITLE
Patch store relationship saving

### DIFF
--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -73,11 +73,8 @@
 
   <div class="col-12">
     <%= f.field_container :stores do %>
-      <%= f.label :stores, I18n.t('spree.stores')%><br />
-      <% Spree::Store.all.each do |store| %>
-        <%= check_box_tag "product[store_ids][]", store.id, @page.stores.include?(store), id: "product_store_id_#{store.id}" %>
-        <%= label_tag "page_store_id_#{store.id}", store.name %>
-      <% end %>
+      <%= f.label :store_ids, plural_resource_name(Spree::Store) %>
+      <%= f.collection_select :store_ids, Spree::Store.all, :id, :name, {}, multiple: true, class: "select2 fullwidth" %>
     <% end %>
   </div>
 


### PR DESCRIPTION
In the latest version of Solidus (2.9.1) and this extension, the store relationship never saves. If you check the box for a store and save, it will be unchecked still. 

Replaced the check boxes for store relationships with a "select2" style input like used in the core when setting multiple stores. See [payment methods form](https://github.com/solidusio/solidus/blob/master/backend/app/views/spree/admin/payment_methods/_form.html.erb#L67) for example.

Now saving stores works properly.