### PR TITLE
Update capybara js driver

### DIFF
--- a/solidus_static_content.gemspec
+++ b/solidus_static_content.gemspec
@@ -33,14 +33,15 @@ Gem::Specification.new do |spec|
   spec.add_dependency "solidus_support"
   spec.add_dependency 'deface', '~> 1.0'
 
-  spec.add_development_dependency 'capybara', '~> 2.7'
+  spec.add_development_dependency "capybara", "~> 3.12"
+  spec.add_development_dependency "puma"
   spec.add_development_dependency 'capybara-screenshot'
   spec.add_development_dependency 'factory_bot', '~> 4.7'
   spec.add_development_dependency 'ffaker'
   spec.add_development_dependency 'database_cleaner', '~> 1.5'
   spec.add_development_dependency 'rspec-rails',  '~> 4.0.0.beta2'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'poltergeist', '~> 1.10'
+  spec.add_development_dependency "apparition"
   spec.add_development_dependency 'selenium-webdriver'
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'pry-rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,6 @@ require "solidus_support/extension/feature_helper"
 RSpec.configure do |config|
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
 end
+
+# A fix for https://github.com/rspec/rspec-rails/issues/1897
+Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
_depends on #39_

Poltergeist has been abandoned for years and throws a bunch of
warnings.

This PR replaces it with Apparition and Puma.