### PR TITLE
Limit sprockets to v3 until it's fixed on Solidus

### DIFF
--- a/solidus_static_content.gemspec
+++ b/solidus_static_content.gemspec
@@ -50,4 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.12'
   spec.add_development_dependency 'solidus_auth_devise'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sprockets', '< 4'
 end


### PR DESCRIPTION
The release of Sprockets v4 is breaking the builds, but that's a problem that should be solved on core, not on the extension