### PR TITLE
Avoid adding the menu item multiple times

### DIFF
--- a/lib/spree_static_content/engine.rb
+++ b/lib/spree_static_content/engine.rb
@@ -4,12 +4,18 @@ module SpreeStaticContent
     isolate_namespace Spree
     engine_name 'spree_static_content'
 
-    def self.activate_menu_items
-       Spree::Backend::Config.menu_items << Spree::Backend::Config.class::MenuItem.new(
+    def self.menu_item
+      @menu_item ||= Spree::Backend::Config.class::MenuItem.new(
         [:pages],
         'file-text',
         condition: -> { can?(:admin, Spree::Page) },
       )
+    end
+
+    def self.activate_menu_items
+      return if Spree::Backend::Config.menu_items.include?(menu_item)
+
+      Spree::Backend::Config.menu_items << menu_item
     end
 
     def self.activate_overrides

--- a/spec/lib/engine_spec.rb
+++ b/spec/lib/engine_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe SpreeStaticContent::Engine do
+  describe '.activate_menu_item' do
+    it 'adds the menu item only once' do
+      described_class.activate_menu_items
+
+      expect {
+        described_class.activate_menu_items
+        described_class.activate_menu_items
+      }.not_to change {Spree::Backend::Config.menu_items.size}
+    end
+  end
+end


### PR DESCRIPTION
Since `config.to_prepare` is called multiple times in development, we need to ensure that the menu is added only once.