### PR TITLE
Auto-generate slug when missing, require presence of a store, attach to the default store by default

### DIFF
--- a/app/controllers/spree/admin/pages_controller.rb
+++ b/app/controllers/spree/admin/pages_controller.rb
@@ -1,3 +1,12 @@
 class Spree::Admin::PagesController < Spree::Admin::ResourceController
-  
+  private
+
+  # Set some default attributes
+  def build_resource
+    super.tap do |resource|
+      if resource.stores.blank?
+        resource.stores << Spree::Store.default
+      end
+    end
+  end
 end

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -6,6 +6,7 @@ class Spree::Page < ActiveRecord::Base
   validates_presence_of :title
   validates_presence_of [:slug, :body], :if => :not_using_foreign_link?
   validates_presence_of :layout, :if => :render_layout_as_partial?
+  validates_presence_of :stores
 
   validates :slug, :uniqueness => true, :if => :not_using_foreign_link?
   validates :foreign_link, :uniqueness => true, :allow_blank => true

--- a/app/models/spree/page.rb
+++ b/app/models/spree/page.rb
@@ -11,6 +11,8 @@ class Spree::Page < ActiveRecord::Base
   validates :slug, :uniqueness => true, :if => :not_using_foreign_link?
   validates :foreign_link, :uniqueness => true, :allow_blank => true
 
+  before_validation :generate_slug, if: :title?
+
   scope :visible, -> { where(:visible => true) }
   scope :header_links, -> { where(:show_in_header => true).visible }
   scope :footer_links, -> { where(:show_in_footer => true).visible }
@@ -51,5 +53,9 @@ private
 
   def not_using_foreign_link?
     foreign_link.blank?
+  end
+
+  def generate_slug
+    self.slug ||= title.parameterize
   end
 end

--- a/lib/spree_static_content/factories.rb
+++ b/lib/spree_static_content/factories.rb
@@ -12,5 +12,7 @@ FactoryBot.define do
         "http://example.com"
       end
     end
+
+    stores { [build(:store)] }
   end
 end

--- a/spec/controllers/spree/admin/pages_controller_spec.rb
+++ b/spec/controllers/spree/admin/pages_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Spree::Admin::PagesController do
+  describe '.build_resource' do
+    it 'pre-assigns the default store' do
+      default_store = create(:store, default: true)
+
+      expect(subject.send(:build_resource).stores).to eq([default_store])
+    end
+  end
+end

--- a/spec/features/spree/admin/pages_spec.rb
+++ b/spec/features/spree/admin/pages_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 RSpec.feature 'Admin Static Content', js: true do
   stub_authorization!
 
+  background do
+    create :store, default: true
+  end
+
   context 'when no page exists' do
     background do
       visit spree.admin_path

--- a/spec/models/spree/page_spec.rb
+++ b/spec/models/spree/page_spec.rb
@@ -9,11 +9,6 @@ describe Spree::Page do
     end
   end
 
-  it 'always add / prefix to slug' do
-    page = create(:page, slug: 'hello')
-    expect(page.slug).to eq '/hello'
-  end
-
   context '.link' do
     it 'return slug if foreign_link blank' do
       page = create(:page, slug: 'hello')
@@ -25,7 +20,6 @@ describe Spree::Page do
       expect(page.link).to eq page.foreign_link
     end
   end
-
 
   context "pages in stores" do
 
@@ -43,4 +37,10 @@ describe Spree::Page do
 
   end
 
+  describe '#slug' do
+    it 'always adds a "/" (slash) prefix to the slug' do
+      page = create(:page, slug: 'hello')
+      expect(page.slug).to eq '/hello'
+    end
+  end
 end

--- a/spec/models/spree/page_spec.rb
+++ b/spec/models/spree/page_spec.rb
@@ -42,5 +42,14 @@ describe Spree::Page do
       page = create(:page, slug: 'hello')
       expect(page.slug).to eq '/hello'
     end
+
+    context 'when a title is present' do
+      it 'is generated from the title' do
+        page = create(:page, slug: nil, title: 'Hello World!')
+
+        expect(page).to be_valid
+        expect(page.slug).to eq('/hello-world')
+      end
+    end
   end
 end


### PR DESCRIPTION
- auto-generate missing slugs
- explicitly require at least one associated store (as expected by frontend)
- prepare new pages with the default store associated 