### PR TITLE
Use the same sidebar logic that Solidus uses

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -8,6 +8,8 @@ class Spree::StaticContentController < Spree::StoreController
     # Assign static_content to let solidus recognize it as the current
     # controller resource, this is used by meta tags and in other places.
     @static_content = @page
+
+    @taxonomies = Spree::Taxonomy.includes(root: :children)
   end
 
   private

--- a/app/views/spree/static_content/show.html.erb
+++ b/app/views/spree/static_content/show.html.erb
@@ -2,11 +2,13 @@
   <%= render :partial => @page.layout %>
 <% else %>
   <% content_for :sidebar do %>
-    <% if @products && @taxon %>
-      <%= render :partial => "spree/shared/filters" %>
-    <% elsif @taxonomies %>
-      <%= render :partial => "spree/shared/taxonomies" %>
-    <% end %>
+    <div data-hook="homepage_sidebar_navigation">
+      <% if "spree/products" == params[:controller] && @taxon %>
+        <%= render partial: 'spree/shared/filters' %>
+      <% else %>
+        <%= render partial: 'spree/shared/taxonomies' %>
+      <% end %>
+    </div>
   <% end %>
 
   <h1><%= @page.title %></h1>


### PR DESCRIPTION
_This PR was extracted from #6_

This change makes the default static_content sidebar use the same logic
that Solidus does in frontend/app/views/spree/products/index.html.erb.

The positive consequence of this change is that now, by default, static
content pages render the same default sidebar that Solidus pages do,
unifying the look and feel and making the static content pages look
"normal".

Fixes #6
Closes #16 