### PR TITLE
Add support for Solidus mounted on subpaths

### DIFF
--- a/app/controllers/spree/static_content_controller.rb
+++ b/app/controllers/spree/static_content_controller.rb
@@ -3,7 +3,7 @@ class Spree::StaticContentController < Spree::StoreController
   layout :determine_layout
 
   def show
-    @page = Spree::Page.by_store(current_store).visible.find_by_slug!(request.path)
+    @page = Spree::Page.by_store(current_store).visible.find_by_slug!(request.path_info)
 
     # Assign static_content to let solidus recognize it as the current
     # controller resource, this is used by meta tags and in other places.

--- a/lib/solidus_static_content.rb
+++ b/lib/solidus_static_content.rb
@@ -5,6 +5,7 @@ require 'solidus_backend'
 require 'deface'
 require 'spree_static_content/engine'
 require 'solidus_static_content/version'
+require 'solidus_static_content/route_matcher'
 
 module StaticPage
   def self.remove_spree_mount_point(path)
@@ -13,9 +14,6 @@ module StaticPage
   end
 end
 
-class Spree::StaticPage
-  def self.matches?(request)
-    return false if request.path =~ /(^\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+)/
-    !Spree::Page.visible.find_by_slug(request.path).nil?
-  end
-end
+# @deprecated Here for legacy purposes
+Spree::StaticPage = SolidusStaticContent::RouteMatcher
+Spree.deprecate_constant :StaticPage

--- a/lib/solidus_static_content.rb
+++ b/lib/solidus_static_content.rb
@@ -9,6 +9,11 @@ require 'solidus_static_content/route_matcher'
 
 module StaticPage
   def self.remove_spree_mount_point(path)
+    Spree::Deprecation.warn(
+      '#remove_spree_mount_point is deprecated with no replacement',
+      caller(1),
+    )
+
     regex = Regexp.new '\A' + Rails.application.routes.url_helpers.spree_path
     path.sub( regex, '').split('?')[0]
   end

--- a/lib/solidus_static_content/route_matcher.rb
+++ b/lib/solidus_static_content/route_matcher.rb
@@ -2,7 +2,7 @@ module SolidusStaticContent::RouteMatcher
   EXCLUDED_PATHS = /^\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+/
 
   def self.matches?(request)
-    path = request.path
+    path = request.path_info
 
     return false if EXCLUDED_PATHS.match? path
 

--- a/lib/solidus_static_content/route_matcher.rb
+++ b/lib/solidus_static_content/route_matcher.rb
@@ -1,0 +1,11 @@
+module SolidusStaticContent::RouteMatcher
+  EXCLUDED_PATHS = /^\/+(admin|account|cart|checkout|content|login|pg\/|orders|products|s\/|session|signup|shipments|states|t\/|tax_categories|user)+/
+
+  def self.matches?(request)
+    path = request.path
+
+    return false if EXCLUDED_PATHS.match? path
+
+    Spree::Page.visible.where(slug: path).exists?
+  end
+end

--- a/spec/lib/spree_static.content_spec.rb
+++ b/spec/lib/spree_static.content_spec.rb
@@ -1,14 +1,5 @@
 require 'spec_helper'
 
-describe StaticPage do
-  context '.remove_spree_mount_point' do
-    specify do
-      path = '/hello'
-      expect(subject.remove_spree_mount_point(path)).to eq 'hello'
-    end
-  end
-end
-
 describe Spree::StaticPage do
   subject { described_class }
 

--- a/spec/lib/spree_static.content_spec.rb
+++ b/spec/lib/spree_static.content_spec.rb
@@ -15,19 +15,19 @@ describe Spree::StaticPage do
   context '.matches?' do
     it 'is true when valid page' do
       page = create(:page, slug: 'hello', visible: true)
-      request = double('request', path: page.slug)
+      request = instance_double(Rack::Request, path_info: page.slug)
       expect(subject.matches?(request)).to be true
     end
 
     it 'is false when using reserved slug name' do
       page = create(:page, slug: 'login', visible: true)
-      request = double('request', path: page.slug)
+      request = instance_double(Rack::Request, path_info: page.slug)
       expect(subject.matches?(request)).to be false
     end
 
     it 'is false when page is not accessible' do
       page = create(:page, slug: 'hello', visible: false)
-      request = double('request', path: page.slug)
+      request = instance_double(Rack::Request, path_info: page.slug)
       expect(subject.matches?(request)).to be false
     end
   end


### PR DESCRIPTION
Fixes #12 

Fixed by using `request.path_info` instead of the full `request.path`. `path_info` is [the standard way](https://tools.ietf.org/html/rfc3875#section-4.1.5) to get the path of the web-app.