### PR TITLE
Replace Spree.t and I18n.t with the "t" helper

### DIFF
--- a/app/views/spree/admin/pages/_form.html.erb
+++ b/app/views/spree/admin/pages/_form.html.erb
@@ -81,7 +81,7 @@
   <div class='row'>
     <div class='col-2'>
       <%= f.field_container :stores do %>
-        <%= f.label :stores, Spree.t(:stores) %>
+        <%= f.label :stores, t("spree.stores") %>
         <br>
         <% Spree::Store.all.each do |store| %>
           <%= check_box_tag 'page[store_ids][]', store.id, @page.stores.include?(store) %>

--- a/app/views/spree/admin/pages/edit.html.erb
+++ b/app/views/spree/admin/pages/edit.html.erb
@@ -5,12 +5,12 @@
 <% admin_breadcrumb(@page.title) %>
 
 <% content_for :page_title do %>
-  <%= Spree.t(:editing_page) %>
+  <%= t("spree.editing_page") %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to I18n.t("spree.back_to_pages"), spree.admin_pages_path, icon: 'arrow-left' %>
+    <%= button_link_to t("spree.back_to_pages"), spree.admin_pages_path, icon: 'arrow-left' %>
   </li>
 <% end %>
 

--- a/app/views/spree/admin/pages/index.html.erb
+++ b/app/views/spree/admin/pages/index.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Page) %>
     <li>
-      <%= link_to I18n.t("spree.new_page"), new_object_url, icon: 'plus' %>
+      <%= link_to t("spree.new_page"), new_object_url, icon: 'plus' %>
     </li>
   <% end %>
 <% end %>
@@ -12,7 +12,7 @@
 <% admin_breadcrumb(plural_resource_name(Spree::Page)) %>
 
 <% content_for :page_title do %>
-  <%= I18n.t("spree.static_content.static_pages") %>
+  <%= t("spree.static_content.static_pages") %>
 <% end %>
 
 <% if @pages.any? %>
@@ -29,7 +29,7 @@
       <tr data-hook="admin_pages_index_headers">
         <th></th>
         <th><%= Spree::Page.human_attribute_name(:title) %></th>
-        <th><%= I18n.t("spree.link") %></th>
+        <th><%= t("spree.link") %></th>
         <th><%= Spree::Page.human_attribute_name(:visible) %></th>
         <th data-hook="admin_pages_index_header_actions" class="actions"></th>
       </tr>
@@ -47,7 +47,7 @@
           <td><%= link_to page.link, page.link, :target => '_blank' %></td>
           <td>
             <span class='pill pill-<%= page.visible ? 'active' : 'inactive' %>'>
-              <%= Spree.t(page.visible? ? :active : :inactive) %>
+              <%= t("spree.#{page.visible? ? :active : :inactive}") %>
             </span>
           </td>
           <td data-hook="admin_pages_index_row_actions" class="actions" >

--- a/app/views/spree/admin/pages/new.html.erb
+++ b/app/views/spree/admin/pages/new.html.erb
@@ -1,12 +1,12 @@
 <%= render partial: 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
-  <%= I18n.t("spree.new_page") %>
+  <%= t("spree.new_page") %>
 <% end %>
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to I18n.t("spree.back_to_pages"), spree.admin_pages_path, icon: "arrow-left" %>
+    <%= button_link_to t("spree.back_to_pages"), spree.admin_pages_path, icon: "arrow-left" %>
   </li>
 <% end %>
 

--- a/app/views/spree/static_content/_static_content_sidebar.html.erb
+++ b/app/views/spree/static_content/_static_content_sidebar.html.erb
@@ -1,6 +1,6 @@
 <% if Spree::Page.by_store(current_store).visible.sidebar_links.any? %>
 <nav id="pages" class="sidebar-item">
-  <h6 class="pages-root"><%= I18n.t("spree.pages") %></h6>
+  <h6 class="pages-root"><%= t("spree.pages") %></h6>
   <ul class="pages-list"><%= render :partial => "spree/static_content/static_content_list", :collection => Spree::Page.visible.sidebar_links, :as => :page %></ul>
 </nav>
 <% end %>


### PR DESCRIPTION
That helper has more features and is the standard way of recalling
translations in Rails.

Fixes #54 