### PR TITLE
Fixes wrong labels, tabs and breadcrumbs

### DIFF
--- a/app/views/spree/admin/pages/edit.html.erb
+++ b/app/views/spree/admin/pages/edit.html.erb
@@ -1,6 +1,5 @@
 <%= render 'spree/admin/shared/pages_tabs' %>
 
-<% admin_breadcrumb(t('spree.settings')) %>
 <% admin_breadcrumb(link_to plural_resource_name(Spree::Page), spree.admin_pages_path) %>
 <% admin_breadcrumb(@page.title) %>
 
@@ -10,11 +9,9 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t("spree.back_to_pages"), spree.admin_pages_path, icon: 'arrow-left' %>
+    <%= button_link_to t("spree.back_to_static_pages_list"), spree.admin_pages_path, icon: 'arrow-left' %>
   </li>
 <% end %>
-
-<%= render partial: 'spree/admin/shared/configuration_menu' %>
 
 <div data-hook='admin_page_edit_form_header'>
   <%= render "spree/shared/error_messages", :target => @page %>

--- a/app/views/spree/admin/pages/index.html.erb
+++ b/app/views/spree/admin/pages/index.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/pages_tabs' %>
 
 <% content_for :page_actions do %>
   <% if can?(:create, Spree::Page) %>
@@ -8,11 +8,8 @@
   <% end %>
 <% end %>
 
-<% admin_breadcrumb(t('spree.settings')) %>
-<% admin_breadcrumb(plural_resource_name(Spree::Page)) %>
-
 <% content_for :page_title do %>
-  <%= t("spree.static_content.static_pages") %>
+  <%= t("spree.static_pages") %>
 <% end %>
 
 <% if @pages.any? %>

--- a/app/views/spree/admin/pages/new.html.erb
+++ b/app/views/spree/admin/pages/new.html.erb
@@ -1,4 +1,6 @@
-<%= render partial: 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/pages_tabs' %>
+
+<% admin_breadcrumb(link_to plural_resource_name(Spree::Page), spree.admin_pages_path) %>
 
 <% content_for :page_title do %>
   <%= t("spree.new_page") %>
@@ -6,7 +8,7 @@
 
 <% content_for :page_actions do %>
   <li>
-    <%= button_link_to t("spree.back_to_pages"), spree.admin_pages_path, icon: "arrow-left" %>
+    <%= button_link_to t("spree.back_to_static_pages_list"), spree.admin_pages_path, icon: "arrow-left" %>
   </li>
 <% end %>
 

--- a/solidus_static_content.gemspec
+++ b/solidus_static_content.gemspec
@@ -52,4 +52,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solidus_auth_devise'
   spec.add_development_dependency 'sprockets', '< 4'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
Hello.

I think the breadcrumb for this module is wrong. In the attached screenshot you can see that the Breadcrumb is "Ajustes (Configuration) / Paginas (Pages) / Static Pages". That is wrong as you can see on the left hand menu "Paginas (Pages)" is at the root level, is not under Configuration.

Another change you can see in the screenshot is the Tab "Tiendas (Stores)". It is wrong as this module is not part of the default Store tab configuration.

There are some other minor translations keys wrong.

I have to add the `solidus_dev_support` dependency in the gem file for the `spec` test to pass. I know there is another pull request much more complete regarding this change, so I'm happy to rebase this branch once that PR is merge before someone approve this.

Regards

![Screenshot from 2019-12-18 05-29-55](https://user-images.githubusercontent.com/11409554/71063070-e5da7680-2163-11ea-9c36-3f4f3f4211c4.png)
