### PR TITLE
Adds Spree::PermissionSets for Pages

### DIFF
--- a/app/models/solidus_static_content/permission_sets/page_display.rb
+++ b/app/models/solidus_static_content/permission_sets/page_display.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusStaticContent
+  module PermissionSets
+    class PageDisplay < Spree::PermissionSets::Base
+      def activate!
+        can [:display, :admin], Spree::Page
+      end
+    end
+  end
+end

--- a/app/models/solidus_static_content/permission_sets/page_management.rb
+++ b/app/models/solidus_static_content/permission_sets/page_management.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusStaticContent
+  module PermissionSets
+    class PageManagement < Spree::PermissionSets::Base
+      def activate!
+        can :manage, Spree::Page
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/pages/new.html.erb
+++ b/app/views/spree/admin/pages/new.html.erb
@@ -21,9 +21,11 @@
 
       <div class='clear'></div>
 
-      <div data-hook='admin_page_new_form_buttons'>
-        <%= render partial: 'spree/admin/shared/new_resource_links' %>
-      </div>
+      <% if can?(:create, Spree::Page) %>
+        <div data-hook='admin_page_new_form_buttons'>
+          <%= render partial: 'spree/admin/shared/new_resource_links' %>
+        </div>
+      <% end %>
     </fieldset>
   <% end %>
 </div>


### PR DESCRIPTION
Hello

I created a couple of permission sets for this extension in order to have more control of access on Pages for admin users. In that way we could have admin users to create, edit or read only pages. The work was done before, but it was missing one page with the right guarding block and the classes to make it extensible and to be integrated with the extension https://github.com/boomerdigital/solidus_user_roles.

Let me know what you think

Happy to fix if you guys spot something wrong.