### PR TITLE
Scroll Update button into view before clicking

### DIFF
--- a/spec/features/spree/admin/pages_spec.rb
+++ b/spec/features/spree/admin/pages_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature 'Admin Static Content', js: true do
       fill_in 'page_title', with: 'Contact'
       fill_in 'page_slug', with: 'contact'
 
+      scroll_to find_button('Update')
       click_button 'Update'
       expect(page).to have_text 'successfully updated!'
     end


### PR DESCRIPTION
It seems there's some weird behaviour in more recent versions of Chrome where attempting to click things with Selenium that aren't scrolled into view errors out with:

    element not interactable: element has zero size

[This Stack Overflow answer](https://stackoverflow.com/a/62137766) explains the situation, but the solution is simple, just scroll the viewport to the thing before clicking.