### PR TITLE
English Translation Key Fix 

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
     admin:
       tab:
         pages: Pages
-    back_to_pages: "Back to static pages list"
+    back_to_static_pages_list: "Back to static pages list"
     page: Page
     pages: Pages
     stores: Stores

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,6 @@ en:
         one: Page
         other: Pages
   spree:
-    stores: Stores
     admin:
       tab:
         pages: Pages


### PR DESCRIPTION
back_to_pages key is never used and is only found in the en locales.  back_to_static_pages_list is the correct key and is used in all the other locals. fixes #72

Also removes a duplication translation key on the en locales. The key 'stores' was listed twice.