### PR TITLE
Add updated Menu Item for Solidus 4.2

### DIFF
--- a/lib/solidus_static_content/engine.rb
+++ b/lib/solidus_static_content/engine.rb
@@ -20,13 +20,23 @@ module SolidusStaticContent
       next unless ::Spree::Backend::Config.respond_to?(:menu_items)
 
       ::Spree::Backend::Config.configure do |config|
-        config.menu_items << config.class::MenuItem.new(
-          [:pages],
-          "file-text",
-          url: :admin_pages_path,
-          condition: -> { can?(:admin, Spree::Page) },
-          match_path: "/pages"
-        )
+        config.menu_items << if Spree.solidus_gem_version >= Gem::Version.new("4.2.0")
+          config.class::MenuItem.new(
+            label: :pages,
+            icon: "ri-file-text-line",
+            url: :admin_pages_path,
+            condition: -> { can?(:admin, Spree::Page) },
+            match_path: "/pages"
+          )
+        else
+          config.class::MenuItem.new(
+            [:pages],
+            "file-text",
+            url: :admin_pages_path,
+            condition: -> { can?(:admin, Spree::Page) },
+            match_path: "/pages"
+          )
+        end
       end
     end
   end

--- a/spec/lib/solidus_static_content/engine_spec.rb
+++ b/spec/lib/solidus_static_content/engine_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SolidusStaticContent::Engine do
 
     it "sets the correct icon for the pages menu item" do
       menu_item = Spree::Backend::Config.menu_items.find { |item| item.label.to_sym == :pages }
-      expect(menu_item.icon).to eq("file-text")
+      expect(menu_item.icon).to eq("ri-file-text-line")
     end
 
     it "sets the correct match_path for the pages menu item" do


### PR DESCRIPTION
This will prevent deprecation warnings and aligns the icon with the new interface. It will still show the old icon on older Solidus installations and the new one for current versions:

<img width="420" height="132" alt="CleanShot 2026-08-24 at 10 37 06@2x" src="https://github.com/user-attachments/assets/b0e1c2aa-4c1e-4240-9129-2201c6c7cc31" />
