### PR TITLE
Add privilege and category method to permission sets

### DIFF
--- a/app/models/solidus_static_content/permission_sets/page_display.rb
+++ b/app/models/solidus_static_content/permission_sets/page_display.rb
@@ -3,6 +3,16 @@
 module SolidusStaticContent
   module PermissionSets
     class PageDisplay < Spree::PermissionSets::Base
+      class << self
+        def privilege
+          :display
+        end
+
+        def category
+          :page
+        end
+      end
+
       def activate!
         can [:display, :admin], Spree::Page
       end

--- a/app/models/solidus_static_content/permission_sets/page_management.rb
+++ b/app/models/solidus_static_content/permission_sets/page_management.rb
@@ -3,6 +3,16 @@
 module SolidusStaticContent
   module PermissionSets
     class PageManagement < Spree::PermissionSets::Base
+      class << self
+        def privilege
+          :management
+        end
+
+        def category
+          :page
+        end
+      end
+
       def activate!
         can :manage, Spree::Page
       end

--- a/spec/models/solidus_static_content/permission_sets/page_display_spec.rb
+++ b/spec/models/solidus_static_content/permission_sets/page_display_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cancan/matchers"
+
+describe SolidusStaticContent::PermissionSets::PageDisplay do
+  let(:ability) { Class.new { include CanCan::Ability }.new }
+
+  subject { ability }
+
+  context "when activated" do
+    before { described_class.new(ability).activate! }
+
+    it { is_expected.to be_able_to(:display, Spree::Page) }
+    it { is_expected.to be_able_to(:admin, Spree::Page) }
+
+    it { is_expected.not_to be_able_to(:update, Spree::Page) }
+    it { is_expected.not_to be_able_to(:create, Spree::Page) }
+    it { is_expected.not_to be_able_to(:destroy, Spree::Page) }
+  end
+
+  context "when not activated" do
+    it { is_expected.not_to be_able_to(:display, Spree::Page) }
+    it { is_expected.not_to be_able_to(:admin, Spree::Page) }
+  end
+
+  describe ".privilege" do
+    it "returns the correct privilege symbol" do
+      expect(described_class.privilege).to eq(:display)
+    end
+  end
+
+  describe ".category" do
+    it "returns the correct category symbol" do
+      expect(described_class.category).to eq(:page)
+    end
+  end
+end

--- a/spec/models/solidus_static_content/permission_sets/page_management_spec.rb
+++ b/spec/models/solidus_static_content/permission_sets/page_management_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "cancan/matchers"
+
+describe SolidusStaticContent::PermissionSets::PageManagement do
+  let(:ability) { Class.new { include CanCan::Ability }.new }
+
+  subject { ability }
+
+  context "when activated" do
+    before { described_class.new(ability).activate! }
+
+    it { is_expected.to be_able_to(:manage, Spree::Page) }
+    it { is_expected.to be_able_to(:display, Spree::Page) }
+    it { is_expected.to be_able_to(:admin, Spree::Page) }
+    it { is_expected.to be_able_to(:update, Spree::Page) }
+    it { is_expected.to be_able_to(:destroy, Spree::Page) }
+  end
+
+  context "when not activated" do
+    it { is_expected.not_to be_able_to(:manage, Spree::Page) }
+    it { is_expected.not_to be_able_to(:admin, Spree::Page) }
+  end
+
+  describe ".privilege" do
+    it "returns the correct privilege symbol" do
+      expect(described_class.privilege).to eq(:management)
+    end
+  end
+
+  describe ".category" do
+    it "returns the correct category symbol" do
+      expect(described_class.category).to eq(:page)
+    end
+  end
+end


### PR DESCRIPTION
All permission sets should have a privilege and a category method, to allow the permission sets seeding in Solidus. Otherwise the user will see a NotImplementedError during the seeding.